### PR TITLE
POSIX compliant syntax

### DIFF
--- a/encpass.sh
+++ b/encpass.sh
@@ -75,8 +75,8 @@ set_password() {
 	stty -echo
 	read CPASSWORD
 	stty echo
-	if [ $PASSWORD == $CPASSWORD ]; then
-		echo $PASSWORD | openssl rsautl -encrypt -pubin -inkey id_rsa.pub.pem -out pass.enc
+	if [ "$PASSWORD" = "$CPASSWORD" ]; then
+		echo "$PASSWORD" | openssl rsautl -encrypt -pubin -inkey id_rsa.pub.pem -out pass.enc
 	else
 		echo "Error: passwords do not match.  Please try again." >&2
 		exit 1

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-source ./encpass.sh
+. ./encpass.sh
 password=$(get_password)
 # Call it specifying a directory
 #password=$(get_password ~/.ssh)


### PR DESCRIPTION
Tested on Ubuntu 16.04 /bin/sh is using dash.
source function is not available 
Fixed password comparison to allow special characters without breaking if statement
