### PR TITLE
Added support for spaces in filenames

### DIFF
--- a/encpass.sh
+++ b/encpass.sh
@@ -47,10 +47,10 @@ checks() {
 		LABEL=$1
 		SECRET_NAME=$2
 	elif [ ! -z $1 ]; then
-		LABEL=$(basename $0)
+		LABEL=$(basename "$0")
 		SECRET_NAME=$1
 	else
-		LABEL=$(basename $0)
+		LABEL=$(basename "$0")
 		SECRET_NAME="password"
 	fi
 


### PR DESCRIPTION
I kept getting a  `syntax error near unexpected token` error when running the script.  I realized that a space in a folder name was responsible for the error while debugging and was able to solve it by adding double quotes to the `$0` variable for the `basename` argument.  Works great now and has a little more compatibility.  Lines 50 and 53 now read `LABEL=$(basename "$0")`